### PR TITLE
Prevent mutation when sorting arrays

### DIFF
--- a/CheckEqual.js
+++ b/CheckEqual.js
@@ -90,7 +90,7 @@ const checkObjectEqual = (objA, objB) => {
  * @version 1.0.0
  */
 const sortArray = arr => {
-  arr.sort((a, b) => {
+  [...arr].sort((a, b) => {
     //if type of neighboring items in array are different, needn't sort
     if (typeof a !== typeof b) return 0;
     //if type of items in array are number or string, sort ascending


### PR DESCRIPTION
With the `.sort()` method the array gets sorted in place, meaning it mutates the original array passed to `checkEqual()` (see [Array.prototype.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)). To prevent this we can call the `.sort()` method on a copy of the original array.